### PR TITLE
1.1.2

### DIFF
--- a/src/GeoCoordinates.Core/Coordinate.cs
+++ b/src/GeoCoordinates.Core/Coordinate.cs
@@ -156,22 +156,14 @@ public class Coordinate
             return true;
         }
 
-        return coordinate.Latitude == Latitude &&
-               coordinate.Longitude == Longitude &&
-               coordinate.Elevation == Elevation;
+        return ToString() == obj.ToString();
     }
 
     /// <inheritdoc/>
-    public override string ToString()
-    {
-        return $"{Latitude}|{Longitude}|{Elevation}";
-    }
+    public override string ToString() => $"{Latitude}|{Longitude}|{Elevation}";
 
     /// <inheritdoc/>
-    public override int GetHashCode()
-    {
-        return HashCode.Combine(Latitude, Longitude, Elevation);
-    }
+    public override int GetHashCode() => ToString().GetHashCode();
 
     /// <inheritdoc/>
     public static bool operator ==(Coordinate c1, Coordinate c2) => c1.Equals(c2);

--- a/src/GeoCoordinates.Core/GeoCoordinates.Core.csproj
+++ b/src/GeoCoordinates.Core/GeoCoordinates.Core.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackageId>GeoCoordinates.Core</PackageId>
-    <Version>1.1.1</Version>
+    <Version>1.1.2</Version>
     <Author>Tobias Filgas</Author>
     <Product>GeoCoordinates</Product>
     <Description>C# library for anyone working with coordinate data.</Description>

--- a/src/GeoCoordinates.Core/GeoCoordinates.Core.csproj
+++ b/src/GeoCoordinates.Core/GeoCoordinates.Core.csproj
@@ -20,9 +20,7 @@
     <RepositoryType>git</RepositoryType>
 
     <PackageReleaseNotes>
-    New GpxHandler.LoadGpxTracks() method for loading tracks from .gpx file.
-    New ToString() method for CoordinatePath class
-    Fixed that documentation is visible outside the project files.
+    Modified the Equals method to compare Coordinate objects using their string representations instead of individual properties, and updated GetHashCode to use the hash code of the string representation rather than combining individual field values.
     </PackageReleaseNotes>
 
   </PropertyGroup>


### PR DESCRIPTION
Modified the Equals method to compare Coordinate objects using their string representations instead of individual properties, and updated GetHashCode to use the hash code of the string representation rather than combining individual field values.